### PR TITLE
Support for generating basic files

### DIFF
--- a/Dockerfile.tpl
+++ b/Dockerfile.tpl
@@ -1,0 +1,28 @@
+FROM {{REGISTRY_IMAGE}}
+MAINTAINER "{{MAINTAINER}}"
+WORKDIR /build/
+
+# First update the base container to latest versions of everything
+RUN yum update -y
+
+# Expecting kmod software version as an input to the build
+ARG KMODVER
+# Grab the software from upstream
+COPY {{KMOD_URL}} ./file.tar.gz
+RUN tar -x --strip-components=1 -f ./file.tar.gz
+
+# Expecting kernel version as an input to the build
+ARG KVER
+# Grab kernel rpms from koji and install them
+RUN yum install -y koji
+RUN koji download-build --rpm --arch=$(uname -m) kernel-core-${KVER}    && \
+    koji download-build --rpm --arch=$(uname -m) kernel-devel-${KVER}   && \
+    koji download-build --rpm --arch=$(uname -m) kernel-modules-${KVER} && \
+    yum install -y ./kernel-{core,devel,modules}-${KVER}.rpm    && \
+    rm -f ./kernel-{core,devel,modules}-${KVER}.rpm
+
+# Prep and build the module
+RUN yum install -y make
+RUN make buildprep KVER=${KVER} KMODVER=${KMODVER}
+RUN make all       KVER=${KVER} KMODVER=${KMODVER}
+RUN make install   KVER=${KVER} KMODVER=${KMODVER}

--- a/generate-files
+++ b/generate-files
@@ -1,0 +1,55 @@
+#!/bin/bash
+# The MIT License
+
+# Copyright (c) 2019 Dusty Mabe
+
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+
+set -eu
+
+main(){
+	read -p "Module Name: " MOD_NAME
+	read -p "Maintainer Email: " MAINTAINER
+	read -p "Registry and Image: " REGISTRY_IMAGE
+	read -p "kmod Version: " MOD_VERSION
+	read -p "kmod URL (with \${KMODVER}): " KMOD_URL
+	if [[ ! "${KMOD_URL}" == *"\${KMODVER}"* ]]; then
+		read -p "The URL does not specify a version. Are you sure you want to continue? (y/n)" CONT
+		if [[ "${CONT}" != "y" ]]; then
+			exit 1
+		fi
+	fi
+	read -p "GIT URL: " GIT_URL
+	read -p "Output Path: " OUTPUT_PATH
+
+	mkdir -p ${OUTPUT_PATH}
+	cp kvc-kmod-lib.sh.tpl ${OUTPUT_PATH}/kvc-${MOD_NAME}-kmod-lib.sh
+	sed -i "s|{{MOD_NAME}}|${MOD_NAME}|" ${OUTPUT_PATH}/kvc-${MOD_NAME}-kmod-lib.sh
+	sed -i "s|{{MOD_VERSION}}|${MOD_VERSION}|" ${OUTPUT_PATH}/kvc-${MOD_NAME}-kmod-lib.sh
+	sed -i "s|{{GIT_URL}}|${GIT_URL}|" ${OUTPUT_PATH}/kvc-${MOD_NAME}-kmod-lib.sh
+
+	cp Dockerfile.tpl ${OUTPUT_PATH}/Dockerfile
+	sed -i "s|{{REGISTRY_IMAGE}}|${REGISTRY_IMAGE}|" ${OUTPUT_PATH}/Dockerfile
+	sed -i "s|{{MAINTAINER}}|${MAINTAINER}|" ${OUTPUT_PATH}/Dockerfile
+	sed -i "s|{{KMOD_URL}}|${KMOD_URL}|" ${OUTPUT_PATH}/Dockerfile
+
+	echo "Move to ${OUTPUT_PATH} and edit kvc-${MOD_NAME}-kmod-lib.sh to fill in the template"
+}
+
+main

--- a/kvc-kmod-lib.sh.tpl
+++ b/kvc-kmod-lib.sh.tpl
@@ -1,0 +1,129 @@
+#!/bin/bash
+
+# The MIT License
+
+# Copyright (c) 2019 Dusty Mabe
+
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+
+set -eux
+
+KMOD_CONTAINER_RUNTIME=/usr/bin/podman
+KMOD_CONTAINER_BUILD_CONTEXT="{{GIT_URL}}"
+KMOD_SOFTWARE_NAME={{MOD_NAME}}
+KMOD_SOFTWARE_VERSION={{MOD_VERSION}}
+KMOD_NAMES=(
+    ${KMOD_SOFTWARE_NAME}
+)
+
+c_run()   { $KMOD_CONTAINER_RUNTIME run -it --rm $@; }
+c_build() { $KMOD_CONTAINER_RUNTIME build  $@; }
+c_images(){ $KMOD_CONTAINER_RUNTIME images $@; }
+c_rmi()   { $KMOD_CONTAINER_RUNTIME rmi    $@; }
+
+build_kmod_container() {
+    kver=$1; image=$2
+    echo "Building ${image} kernel module container..."
+    c_build -t ${image}                              \
+        --label="name=${KMOD_SOFTWARE_NAME}"         \
+        --build-arg KVER=${kver}                     \
+        --build-arg KMODVER=${KMOD_SOFTWARE_VERSION} \
+        ${KMOD_CONTAINER_BUILD_CONTEXT}
+}
+
+is_kmod_loaded() {
+    module=${1//-/_} # replace any dashes with underscore
+    if lsmod | grep "${module}" &>/dev/null; then
+        return 0
+    else
+        return 1
+    fi
+}
+
+build_kmods() {
+    # Image name will be modname-modversion:kversion
+    kver=$1
+    image="${KMOD_SOFTWARE_NAME}-${KMOD_SOFTWARE_VERSION}:${kver}"
+
+    # Check to see if it's already built
+    if [ ! -z "$(c_images $image --quiet 2>/dev/null)" ]; then
+        echo "The ${image} kernel module container is already built"
+    else
+        build_kmod_container $kver $image
+    fi
+
+    # Sanity checks for each module to load
+    for module in ${KMOD_NAMES[@]}; do
+        module=${module//_/-} # replace any underscores with dash
+        # Sanity check to make sure the built kernel modules were really
+        # built against the correct module software version
+        # Note the tr to delete the trailing carriage return
+        x=$(c_run $image modinfo -F version "/lib/modules/${kver}/${module}.ko" | \
+                                                                            tr -d '\r')
+        if [ "${x}" != "${KMOD_SOFTWARE_VERSION}" ]; then
+            echo "Module version mismatch within container.. rebuilding ${image}..."
+            build_kmod_container $kver $image
+        fi
+        # Sanity check to make sure the built kernel modules were really
+        # built against the desired kernel version
+        x=$(c_run $image modinfo -F vermagic "/lib/modules/${kver}/${module}.ko" | \
+                                                                        cut -d ' ' -f 1)
+        if [ "${x}" != "${kver}" ]; then
+            echo "Module not built against ${kver}.. rebuilding ${image}..."
+            build_kmod_container $kver $image
+        fi
+    done
+
+    # get rid of any dangling containers if they exist
+    rmi1=$(c_images -q -f label="name=${KMOD_SOFTWARE_NAME}" -f dangling=true)
+    # keep around any non-dangling images for only the most recent 3 kernels
+    rmi2=$(c_images -q -f label="name=${KMOD_SOFTWARE_NAME}" -f dangling=false | tail -n +4)
+    if [ ! -z "${rmi1}" -o ! -z "${rmi2}" ]; then
+        echo "Cleaning up old kernel module container builds..."
+        c_rmi -f $rmi1 $rmi2
+    fi
+}
+
+load_kmods() {
+    # Image name will be modname-modversion:kversion
+    kver=$1
+    image="${KMOD_SOFTWARE_NAME}-${KMOD_SOFTWARE_VERSION}:${kver}"
+
+    echo "Loading kernel modules using the kernel module container..."
+    for module in ${KMOD_NAMES[@]}; do
+        if is_kmod_loaded ${module}; then
+            echo "Kernel module ${module} already loaded"
+        else
+            module=${module//_/-} # replace any underscores with dash
+            c_run --privileged $image insmod /usr/lib/modules/${kver}/${module}.ko
+        fi
+    done
+}
+
+unload_kmods() {
+    echo "Unloading kernel modules..."
+    for module in ${KMOD_NAMES[@]}; do
+        if is_kmod_loaded ${module}; then
+            module=${module//-/_} # replace any dashes with underscore
+            rmmod "${module}"
+        else
+            echo "Kernel module ${module} already unloaded"
+        fi
+    done
+}


### PR DESCRIPTION
May be helpful

```
$ ./generate-files
Module Name: test
Maintainer Email: test
Registry and Image: fedora:30
kmod Version: 123
kmod URL (with ${KMODVER}): http://127.0.0.1
The URL does not specify a version. Are you sure you want to continue? (y/n) y
GIT URL: http://127.0.0.1/git
Output Path: /tmp/ok
Move to /tmp/ok and edit kvc-asd-kmod-lib.sh to fill in the template
$
```

```
$ ./generate-files
Module Name: test
Maintainer Email: asd
Registry and Image: asd
kmod Version: 123
kmod URL (with ${KMODVER}): sdgf
The URL does not specify a version. Are you sure you want to continue? (y/n) n
$
```