### PR TITLE
Get the correct container environment

### DIFF
--- a/kmods-via-containers
+++ b/kmods-via-containers
@@ -103,3 +103,6 @@ case "${KVC_ACTION}" in
         echo "wrapper     Run userspace tools from within the container"
         exit 1
 esac
+
+
+

--- a/kmods-via-containers.conf
+++ b/kmods-via-containers.conf
@@ -2,5 +2,17 @@
 # kmods-via-containers software stack that intends to build
 # and deliver kernel modules via container builds/images.
 
+
+# The behaviour of KVC depends on the container runtime 
+# podman     - for day-1 out-of-tree drivers
+# kubernetes - for day-2 out-of-tree drivers
+get_container_environment() {
+        if awk -F/ '$2 == "kubepods.slice"' /proc/self/cgroup | read non_empty_input; then
+                echo kubernetes
+        else 
+                echo podman
+        fi
+}
+
 # The container runtime to use for building/executing containers
-KVC_CONTAINER_RUNTIME=podman
+KVC_CONTAINER_RUNTIME=$(get_container_environment)


### PR DESCRIPTION
We can run KVC outside or inside of a container. If run inside of OpenShift/k8s we want to expose this to KVC so we can use the right functions. 